### PR TITLE
imageservice: Fix a typo in requests.go

### DIFF
--- a/openstack/imageservice/v2/images/requests.go
+++ b/openstack/imageservice/v2/images/requests.go
@@ -228,7 +228,7 @@ type UpdateVisibility struct {
 // ToImagePatchMap builder
 func (u UpdateVisibility) ToImagePatchMap() map[string]interface{} {
 	m := map[string]interface{}{}
-	m["op"] = "relace"
+	m["op"] = "replace"
 	m["path"] = "/visibility"
 	m["value"] = u.Visibility
 	return m


### PR DESCRIPTION
This typo breaks the image modification support in ciao-cli.
